### PR TITLE
Update to Epiphany 3.36.4

### DIFF
--- a/org.gnome.Epiphany.json
+++ b/org.gnome.Epiphany.json
@@ -52,8 +52,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/epiphany/3.36/epiphany-3.36.2.tar.xz",
-                    "sha256": "c2e676aa0fe211809a5e7e8a7e461d182890f253c53f4610f2610094b6fbfb5e"
+                    "url" : "https://download.gnome.org/sources/epiphany/3.36/epiphany-3.36.4.tar.xz",
+                    "sha256": "588a75b1588f5a509c33cf0be6a38a0f4fc1748eeb499a51d991ddef485242bf"
                 }
             ]
         }


### PR DESCRIPTION
Hello. Let's update to 3.36.4? This update contains important bug fix with [Firefox Sync](https://gitlab.gnome.org/GNOME/epiphany/-/issues/1233). I've tested this build and LGTM so far.