### PR TITLE
Include elementary stylesheet

### DIFF
--- a/org.gnome.Epiphany.json
+++ b/org.gnome.Epiphany.json
@@ -17,6 +17,87 @@
     ],
     "modules" : [
         {
+            "name": "elementary-icons",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/elementary/icons.git",
+                    "commit": "9e7ace3d6c1d1e3b5ea64012a371e46039bf044a"
+                }
+            ],
+            "modules": [
+                {
+                    "name": "xcursorgen",
+                    "cleanup": [
+                        "*"
+                    ],
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "https://gitlab.freedesktop.org/xorg/app/xcursorgen.git",
+                            "tag": "xcursorgen-1.0.7"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "elementary-stylesheet",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/elementary/stylesheet.git",
+                    "commit": "3047efbfabe723e0b0f2b8ee3d53bed528be4b14"
+                }
+            ],
+            "modules": [
+                {
+                    "name": "sassc",
+                    "cleanup": [
+                        "*"
+                    ],
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "https://github.com/sass/sassc.git",
+                            "tag": "3.6.1"
+                        },
+                        {
+                            "type": "script",
+                            "dest-filename": "autogen.sh",
+                            "commands": [
+                                "autoreconf -si"
+                            ]
+                        }
+                    ],
+                    "modules": [
+                        {
+                            "name": "libsass",
+                            "cleanup": [
+                                "*"
+                            ],
+                            "sources": [
+                                {
+                                    "type": "git",
+                                    "url": "https://github.com/sass/libsass.git",
+                                    "tag": "3.6.4"
+                                },
+                                {
+                                    "type": "script",
+                                    "dest-filename": "autogen.sh",
+                                    "commands": [
+                                        "autoreconf -si"
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "name" : "libdazzle",
             "buildsystem" : "meson",
             "sources" : [


### PR DESCRIPTION
Backport of https://gitlab.gnome.org/GNOME/epiphany/-/merge_requests/858

When running under Pantheon, we need the stylesheet to be available
inside the sandbox to avoid falling back to Adwaita. In the past
we relied on the Flatpak GTK extensions, but this isn't going to
work going forward for ElemetnaryOS 6 version of the stylesheet as
it provides multiple versions of the gtk theme, all with different
ids.