### PR TITLE
Bump to 44

### DIFF
--- a/org.gnome.Epiphany.json
+++ b/org.gnome.Epiphany.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Epiphany",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
     "command": "epiphany",
     "finish-args": [
@@ -130,7 +130,7 @@
             "name": "libportal",
             "buildsystem": "meson",
             "config-opts": [
-                "-Dbackends=gtk3",
+                "-Dbackends=gtk4",
                 "-Dintrospection=false",
                 "-Ddocs=false"
             ],
@@ -154,8 +154,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/epiphany/43/epiphany-43.1.tar.xz",
-                    "sha256": "e86ead27cb9982815150664de3bf20faf375f77b8065b02b31180c65b6bbebb4",
+                    "url": "https://download.gnome.org/sources/epiphany/44/epiphany-44.0.tar.xz",
+                    "sha256": "aabdc9de80c409073676e00e15ba97187715e4b84bc776fe86db86d0f8140bb1",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "epiphany"


### PR DESCRIPTION
Update to version 44 runtime and epiphany. Changed the backend for libportal to support GTK4 and drop GTK3.

Tested and built locally without any issues.

```
$ flatpak run org.gnome.Epiphany --version
Web 44.0
```