### PR TITLE
json: Build Gstreamer-vaapi as a module

### DIFF
--- a/org.gnome.Epiphany.json
+++ b/org.gnome.Epiphany.json
@@ -25,18 +25,6 @@
                     "commit": "5b7ffe85cded2fa3ce682510706601c1289da004"
                 }
             ],
-    "modules": [
-        {
-            "name": "gstreamer-vaapi",
-            "buildsystem": "meson",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/GStreamer/gstreamer-vaapi",
-                    "commit": "c3ddb29cb2860374f9efbed495af7b0eead08312"
-                }
-            }
-            ],
             "modules": [
                 {
                     "name": "xcursorgen",
@@ -131,6 +119,17 @@
                     "type": "git",
                     "url": "https://github.com/elementary/granite.git",
                     "commit": "e7447e373fa1d2906af4bfcebce30c6193ddaa8f"
+                }
+            ]
+        },
+        {
+            "name": "gstreamer-vaapi",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/GStreamer/gstreamer-vaapi",
+                    "commit": "c3ddb29cb2860374f9efbed495af7b0eead08312"
                 }
             ]
         },

--- a/org.gnome.Epiphany.json
+++ b/org.gnome.Epiphany.json
@@ -25,6 +25,23 @@
                     "commit": "5b7ffe85cded2fa3ce682510706601c1289da004"
                 }
             ],
+    "modules": [
+        {
+            "name": "gstreamer",
+               "cleanup": [
+                        "*"
+                    ],
+           "config-opts": [
+              "-Dvaapi=enabled"
+            ],
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.freedesktop.org/gstreamer/gstreamer",
+                    "commit": "1.22.6"
+                }
+            ],
             "modules": [
                 {
                     "name": "xcursorgen",
@@ -119,17 +136,6 @@
                     "type": "git",
                     "url": "https://github.com/elementary/granite.git",
                     "commit": "e7447e373fa1d2906af4bfcebce30c6193ddaa8f"
-                }
-            ]
-        },
-        {
-            "name": "gstreamer-vaapi",
-            "buildsystem": "meson",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/GStreamer/gstreamer-vaapi",
-                    "commit": "c3ddb29cb2860374f9efbed495af7b0eead08312"
                 }
             ]
         },

--- a/org.gnome.Epiphany.json
+++ b/org.gnome.Epiphany.json
@@ -25,6 +25,17 @@
                     "commit": "5b7ffe85cded2fa3ce682510706601c1289da004"
                 }
             ],
+    "modules": [
+        {
+            "name": "gstreamer-vaapi",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/GStreamer/gstreamer-vaapi",
+                    "commit": "c3ddb29cb2860374f9efbed495af7b0eead08312"
+                }
+            ],
             "modules": [
                 {
                     "name": "xcursorgen",

--- a/org.gnome.Epiphany.json
+++ b/org.gnome.Epiphany.json
@@ -35,6 +35,7 @@
                     "url": "https://github.com/GStreamer/gstreamer-vaapi",
                     "commit": "c3ddb29cb2860374f9efbed495af7b0eead08312"
                 }
+            }
             ],
             "modules": [
                 {


### PR DESCRIPTION
Gstreamer is now in release 1.19 i think that is possible to be stable for use now, but is needed more testing