### PR TITLE
json: use a env var to ensure that Gstreamer VA will be the max priority

### DIFF
--- a/org.gnome.Epiphany.json
+++ b/org.gnome.Epiphany.json
@@ -12,7 +12,8 @@
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--socket=wayland",
-        "--system-talk-name=org.freedesktop.GeoClue2"
+        "--system-talk-name=org.freedesktop.GeoClue2",
+        "--env=GST_PLUGIN_FEATURE_RANK=vah264dec:MAX,vavp8dec:MAX,vavp9dec:MAX,vaav1dec:MAX"
     ],
     "modules": [
         {


### PR DESCRIPTION
This force to Gstreamer VA will be the max priority, can be possible to add more parameters in this env to use nvdecvp8 and v4l2codec but idk if Freedesktop SDKs using gstreamer with v4l2codecs enabled[](url)
![Captura de tela de 2023-09-29 21-57-34](https://github.com/flathub/org.gnome.Epiphany/assets/128154816/8353495a-c606-4df6-8367-fa6444187596)
